### PR TITLE
Fixed blank file field support

### DIFF
--- a/app/views/fields/carrierwave/_file.html.erb
+++ b/app/views/fields/carrierwave/_file.html.erb
@@ -1,1 +1,5 @@
-<%= link_to (file.filename || file.path).split('/').last, file.url, target: '_blank' %>
+<% if filepath = file.filename || file.path %>
+  <%= link_to filepath.split('/').last, file.url, target: '_blank' %>
+<% else %>
+  -
+<% end %>


### PR DESCRIPTION
When image field value is nil, error message raise like a below.

undefined method `split' for nil:NilClass

New image fielid ought to nil, so `new` action is going to down, now.
