### PR TITLE
Handle missing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.1.2](https://github.com/zooppa/administrate-field-carrierwave/tree/v0.1.2) (2017-03-21)
+[Full Changelog](https://github.com/zooppa/administrate-field-carrierwave/compare/v0.1.1...v0.1.2)
+
+* Fix case of missing file
+
 ## [v0.1.1](https://github.com/zooppa/administrate-field-carrierwave/tree/v0.1.1) (2017-03-20)
 [Full Changelog](https://github.com/zooppa/administrate-field-carrierwave/compare/v0.1.0...v0.1.1)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A plugin to upload and preview Carrierwave attachments in [Administrate].
 Add it to your `Gemfile`:
 
 ```ruby
-gem 'administrate-field-carrierwave', '~> 0.1.1'
+gem 'administrate-field-carrierwave', '~> 0.1.2'
 ```
 
 Run:

--- a/administrate-field-carrierwave.gemspec
+++ b/administrate-field-carrierwave.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name = 'administrate-field-carrierwave'
-  gem.version = '0.1.1'
+  gem.version = '0.1.2'
   gem.authors = ['Michele Gerarduzzi']
   gem.email = ['michele.gerarduzzi@gmail.com']
   gem.homepage = 'https://github.com/zooppa/administrate-field-carrierwave'

--- a/app/views/fields/carrierwave/_index.html.erb
+++ b/app/views/fields/carrierwave/_index.html.erb
@@ -13,6 +13,8 @@ opens in a new window/tab, or the total number of attached files
 
 <% if field.multiple? %>
   <%= pluralize(field.files.size, field.attribute.to_s.humanize.downcase) %>
-<% else %>
+<% elsif field.file.present? %>
   <%= link_to 'View', field.file.url, title: field.file.filename, target: '_blank' %>
+<% else %>
+  -
 <% end %>

--- a/app/views/fields/carrierwave/_show.html.erb
+++ b/app/views/fields/carrierwave/_show.html.erb
@@ -24,7 +24,9 @@ for this attribute
 <% else %>
   <% if field.image.present? %>
     <%= render 'fields/carrierwave/preview', file: field.file, field: field %>
-  <% else %>
+  <% elsif field.file.present? %>
     <%= render 'fields/carrierwave/file', file: field.file %>
+  <% else %>
+      -
   <% end %>
 <% end %>


### PR DESCRIPTION
The gem was blowing up when trying to display a `#show` field with a missing file. This tiny patch fixes that problem.