### PR TITLE
No preview is shown when appropriate version is not ready.

### DIFF
--- a/app/views/fields/carrierwave/_show.html.erb
+++ b/app/views/fields/carrierwave/_show.html.erb
@@ -22,7 +22,7 @@ for this attribute
     <span>No file(s) uploaded yet</span>
   <% end %>
 <% else %>
-  <% if field.image.present? && field.data.model.persisted? %>
+  <% if field.image.present? && field.data.model.persisted? && field.file.version_exists?(field.image) %>
     <%= render 'fields/carrierwave/preview', file: field.file, field: field %>
   <% elsif field.file.present? %>
     <%= render 'fields/carrierwave/file', file: field.file %>


### PR DESCRIPTION
Fix: The appropriate version may not be defined in the uploader yet, making it crash.