### PR TITLE
Add remove and remote_url options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ end
 * `image` (default: `nil`): a [version] that will be displayed in an `<img>` element.
 * `image_on_index` (default: `false`): whether or not to show the image itself on the index list view. The default behavior (when false) is to display a "View" link that opens the image in a new tab/window when clicked.
 * `multiple` (default: `false`): allows uploading of multiple files. **ATTENTION 🚨**: [requires CarrierWave’s `master` branch](https://github.com/carrierwaveuploader/carrierwave#multiple-file-uploads). Uploaded files will replace the current ones – if present – and not add to them.
+* `remove` (default: `false`): allow to remove previously uploaded files. **ATTENTION 🚨** extend [`permitted_attributes`](https://github.com/thoughtbot/administrate/issues/990#issuecomment-339066788) by `remove_FIELD`
+* `remote_url` (default: `false`): allow uploading files from a remote location. **ATTENTION 🚨** extend [`permitted_attributes`](https://github.com/thoughtbot/administrate/issues/990#issuecomment-339066788) by `remote_FIELD_url`
 
 ## About
 

--- a/app/views/fields/carrierwave/_form.html.erb
+++ b/app/views/fields/carrierwave/_form.html.erb
@@ -20,4 +20,7 @@ attachment(s) for this attribute
   <%= f.file_field field.attribute, multiple: field.multiple? %>
   <br />
   <%= render 'fields/carrierwave/show', field: field %>
+
+  <%= f.text_field "remote_#{field.attribute}_url" if field.remote_url? %>
+  <%= f.check_box "remove_#{field.attribute}" if field.remove? %>
 </div>

--- a/app/views/fields/carrierwave/_form.html.erb
+++ b/app/views/fields/carrierwave/_form.html.erb
@@ -18,7 +18,7 @@ attachment(s) for this attribute
 </div>
 <div class="field-unit__field">
   <%= f.file_field field.attribute, multiple: field.multiple? %>
-  <%= f.text_field "remote_#{field.attribute}_url", placeholder: "remote url" if field.remote_url? %>
+  <%= f.text_field "remote_#{field.attribute}_url", placeholder: "Remote URL" if field.remote_url? %>
   <br />
   <%= render 'fields/carrierwave/show', field: field %>
 

--- a/app/views/fields/carrierwave/_form.html.erb
+++ b/app/views/fields/carrierwave/_form.html.erb
@@ -18,9 +18,11 @@ attachment(s) for this attribute
 </div>
 <div class="field-unit__field">
   <%= f.file_field field.attribute, multiple: field.multiple? %>
+  <%= f.text_field "remote_#{field.attribute}_url", placeholder: "remote url" if field.remote_url? %>
   <br />
   <%= render 'fields/carrierwave/show', field: field %>
 
-  <%= f.text_field "remote_#{field.attribute}_url" if field.remote_url? %>
-  <%= f.check_box "remove_#{field.attribute}" if field.remove? %>
+  <% if field.remove? %>
+    <label><%= f.check_box "remove_#{field.attribute}" %> <%= "Remove #{field.attribute}" %></label>
+  <% end %>
 </div>

--- a/app/views/fields/carrierwave/_form.html.erb
+++ b/app/views/fields/carrierwave/_form.html.erb
@@ -22,7 +22,7 @@ attachment(s) for this attribute
   <br />
   <%= render 'fields/carrierwave/show', field: field %>
 
-  <% if field.remove? %>
-    <label><%= f.check_box "remove_#{field.attribute}" %> <%= "Remove #{field.attribute}" %></label>
-  <% end %>
+  <%= f.label "remove_#{field.attribute}" do %>
+    <%= f.check_box "remove_#{field.attribute}" %> Remove <%= field.attribute %>
+  <% end if field.remove? %>
 </div>

--- a/lib/administrate/field/carrierwave.rb
+++ b/lib/administrate/field/carrierwave.rb
@@ -18,6 +18,14 @@ module Administrate
         options.fetch(:multiple, false)
       end
 
+      def remove?
+        options.fetch(:remove, false)
+      end
+
+      def remote_url?
+        options.fetch(:remote_url, false)
+      end
+
       # One-element array when single file field, array of files when multiple
       def files
         Array[*data]


### PR DESCRIPTION
Ciao @michelegera

Needed these options for a project of mine.

* add `remove` option
  * https://github.com/carrierwaveuploader/carrierwave#removing-uploaded-files
* add `remote_url` option
  * https://github.com/carrierwaveuploader/carrierwave#uploading-files-from-a-remote-location
* add `text_field` for remote_FIELD_url
* add `check_box` for remove_FIELD