### PR TITLE
Fix the crash that happens when no uploaded image exists

### DIFF
--- a/app/views/fields/carrierwave/_show.html.erb
+++ b/app/views/fields/carrierwave/_show.html.erb
@@ -22,7 +22,7 @@ for this attribute
     <span>No file(s) uploaded yet</span>
   <% end %>
 <% else %>
-  <% if field.image.present? && field.data.model.persisted? && field.file.version_exists?(field.image) %>
+  <% if field.image.present? && field.data.model.persisted? && field.data.file.present? %>
     <%= render 'fields/carrierwave/preview', file: field.file, field: field %>
   <% elsif field.file.present? %>
     <%= render 'fields/carrierwave/file', file: field.file %>


### PR DESCRIPTION
This PR fixes an issue that caused a crash when no image is originally uploaded with a new record, or when an uploaded image is removed.